### PR TITLE
[CSS] Fix för stora emojis

### DIFF
--- a/style.css
+++ b/style.css
@@ -1688,6 +1688,14 @@ ol.comment-list #respond {
   padding-left: 90px;
   padding-top: 15px!important;
 }
+
+img[src*="wp-includes/images/smilies/"]{
+    width: 20px;
+    height: 20px;
+    max-height: 20px;
+    vertical-align: middle;
+}
+
 /* ==========================================================================
   Translation projects
 ============================================================================ */


### PR DESCRIPTION
CSS-kod för att sätta originalstorlek på emojis som inte har css klass :) 
Fixar:
https://github.com/wpsvse/wpsv.se/issues/159